### PR TITLE
Update book_list.pug

### DIFF
--- a/views/book_list.pug
+++ b/views/book_list.pug
@@ -7,7 +7,7 @@ block content
   each book in book_list
     li 
       a(href=book.url) #{book.title} 
-      | (#{book.author.name})
+      | (#{book.author})
 
   else
     li There are no books.


### PR DESCRIPTION
The All Books view keeps showing a null value error because I think the pug template originally referred to an author.name value while the controller only refers to an author construct, not an author.name value.  All Books view seems to populate properly with this change.