### PR TITLE
Removed deprecated requires for express-validator

### DIFF
--- a/controllers/authorController.js
+++ b/controllers/authorController.js
@@ -2,8 +2,8 @@ var Author = require('../models/author')
 var async = require('async')
 var Book = require('../models/book')
 
-const { body, validationResult } = require('express-validator/check');
-const { sanitizeBody } = require('express-validator/filter');
+const { body, validationResult } = require('express-validator');
+const { sanitizeBody } = require('express-validator');
 
 // Display list of all Authors.
 exports.author_list = function (req, res, next) {

--- a/controllers/bookController.js
+++ b/controllers/bookController.js
@@ -3,8 +3,8 @@ var Author = require('../models/author');
 var Genre = require('../models/genre');
 var BookInstance = require('../models/bookinstance');
 
-const { body,validationResult } = require('express-validator/check');
-const { sanitizeBody } = require('express-validator/filter');
+const { body,validationResult } = require('express-validator');
+const { sanitizeBody } = require('express-validator');
 
 var async = require('async');
 

--- a/controllers/bookinstanceController.js
+++ b/controllers/bookinstanceController.js
@@ -2,8 +2,8 @@ var BookInstance = require('../models/bookinstance')
 var Book = require('../models/book')
 var async = require('async')
 
-const { body,validationResult } = require('express-validator/check');
-const { sanitizeBody } = require('express-validator/filter');
+const { body,validationResult } = require('express-validator');
+const { sanitizeBody } = require('express-validator');
 
 // Display list of all BookInstances.
 exports.bookinstance_list = function(req, res, next) {

--- a/controllers/genreController.js
+++ b/controllers/genreController.js
@@ -2,8 +2,8 @@ var Genre = require('../models/genre');
 var Book = require('../models/book');
 var async = require('async');
 
-const { body,validationResult } = require('express-validator/check');
-const { sanitizeBody } = require('express-validator/filter');
+const { body,validationResult } = require('express-validator');
+const { sanitizeBody } = require('express-validator');
 
 // Display list of all Genre.
 exports.genre_list = function(req, res, next) {


### PR DESCRIPTION
Removed deprecated requires for express-validator

Fixes #81 