### PR TITLE
Update author.js, correcting schema's String field validator from 'max' to 'maxlength'

### DIFF
--- a/models/author.js
+++ b/models/author.js
@@ -4,8 +4,8 @@ var moment = require('moment'); // For date handling.
 var Schema = mongoose.Schema;
 
 var AuthorSchema = new Schema({
-  first_name: { type: String, required: true, max: 100 },
-  family_name: { type: String, required: true, max: 100 },
+  first_name: { type: String, required: true, maxlength: 100 },
+  family_name: { type: String, required: true, maxlength: 100 },
   date_of_birth: { type: Date },
   date_of_death: { type: Date }
 });


### PR DESCRIPTION
Changed the schemas validator from 'max' to 'maxlength', as 'maxlength' is the proper validator for String fields. ('max' would be correct for Number fields).

cf.:
https://mongoosejs.com/docs/validation.html#built-in-validators
https://wiki.developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose

I fixed the instance of the example in the lesson. The lesson's Validation section already stated the correct built-in validators.