### PR TITLE
Update genre.js - fix SchemaStringOptions

### DIFF
--- a/models/genre.js
+++ b/models/genre.js
@@ -3,7 +3,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var GenreSchema = new Schema({
-    name: {type: String, required: true, min: 3, max: 100}
+    name: {type: String, required: true, minlength: 3, maxlength: 100}
 });
 
 // Virtual for this genre instance URL.


### PR DESCRIPTION
according to Mongoose documentation, min and max are not options for String type validation
the options should be minlength and maxlength
https://mongoosejs.com/docs/api.html#schemastringoptions_SchemaStringOptions-minlength
https://mongoosejs.com/docs/api.html#schemastringoptions_SchemaStringOptions-maxlength