### PR TITLE
Update book_detail.pug - fix h1 element's text

### DIFF
--- a/views/book_detail.pug
+++ b/views/book_detail.pug
@@ -1,7 +1,7 @@
 extends layout
 
 block content
-  h1 #{title}: #{book.title}
+  h1 Title: #{book.title}
   
   p #[strong Author:] 
     a(href=book.author.url) #{book.author.name}


### PR DESCRIPTION
Currently the title is shown twice.
We want to show the string "Title: " appended by the title.