### PR TITLE
Update book_detail.pug

### DIFF
--- a/views/book_detail.pug
+++ b/views/book_detail.pug
@@ -1,7 +1,7 @@
 extends layout
 
 block content
-  h1 #{title}: #{book.title}
+  h1 Title: #{book.title}
   
   p #[strong Author:] 
     a(href=book.author.url) #{book.author.name}


### PR DESCRIPTION
The h1 should be 'Title: #{book.title}' without accessing the title variable.  Since the variable is the same as the book title it passes that value to the layout.pug view to use as the webpage title.  Otherwise, the page renders the h1 as  'SomeBookTitle: SomeBookTitle'