### PR TITLE
Update genreController.js - fix min length check

### DIFF
--- a/controllers/genreController.js
+++ b/controllers/genreController.js
@@ -54,7 +54,7 @@ exports.genre_create_get = function(req, res, next) {
 exports.genre_create_post = [
 
     // Validate and santise the name field.
-    body('name', 'Genre name required').trim().isLength({ min: 1 }).escape(),
+    body('name', 'Genre name must contain at least 3 characters').trim().isLength({ min: 3 }).escape(),
 
     // Process request after validation and sanitization.
     (req, res, next) => {
@@ -171,7 +171,7 @@ exports.genre_update_get = function(req, res, next) {
 exports.genre_update_post = [
    
     // Validate and sanitze the name field.
-    body('name', 'Genre name required').trim().isLength({ min: 1 }).escape(),
+    body('name', 'Genre name must contain at least 3 characters').trim().isLength({ min: 3 }).escape(),
     
 
     // Process request after validation and sanitization.


### PR DESCRIPTION
in the genre model, we define GenreSchema with minlength of 3
if you try to type name of length less than 3 characters, then you get this error:

Genre validation failed: name: Path `name` (`Ab`) is shorter than the minimum allowed length (3).
ValidationError: Genre validation failed: name: Path `name` (`Ab`) is shorter than the minimum allowed length (3).
    at model.Document.invalidate (/mnt/c/Users/arpax/Desktop/Ubuntu/express-locallibrary-tutorial/node_modules/mongoose/lib/document.js:2626:32)
    at /mnt/c/Users/arpax/Desktop/Ubuntu/express-locallibrary-tutorial/node_modules/mongoose/lib/document.js:2446:17
    at /mnt/c/Users/arpax/Desktop/Ubuntu/express-locallibrary-tutorial/node_modules/mongoose/lib/schematype.js:1225:9
    at processTicksAndRejections (internal/process/task_queues.js:75:11)
    at runNextTicks (internal/process/task_queues.js:62:3)
    at processImmediate (internal/timers.js:434:9)

by the way we should also check max length in all the controllers
and maybe there is better way to do it like exporting min and max constants from the relevant models