### PR TITLE
Populatedb - change to async/await semantics

### DIFF
--- a/populatedb.js
+++ b/populatedb.js
@@ -1,229 +1,207 @@
 #! /usr/bin/env node
 
-console.log('This script populates some test books, authors, genres and bookinstances to your database. Specified database as argument - e.g.: node populatedb "mongodb+srv://cooluser:coolpassword@cluster0.lz91hw2.mongodb.net/local_library?retryWrites=true&w=majority"');
+console.log(
+  'This script populates some test books, authors, genres and bookinstances to your database. Specified database as argument - e.g.: node populatedb "mongodb+srv://cooluser:coolpassword@cluster0.lz91hw2.mongodb.net/local_library?retryWrites=true&w=majority"'
+);
 
 // Get arguments passed on command line
 const userArgs = process.argv.slice(2);
 
-const async = require('async')
-const Book = require('./models/book')
-const Author = require('./models/author')
-const Genre = require('./models/genre')
-const BookInstance = require('./models/bookinstance')
+const Book = require("./models/book");
+const Author = require("./models/author");
+const Genre = require("./models/genre");
+const BookInstance = require("./models/bookinstance");
 
+const genres = [];
+const authors = [];
+const books = [];
+const bookinstances = [];
 
-const mongoose = require('mongoose');
-mongoose.set('strictQuery', false); // Prepare for Mongoose 7
+const mongoose = require("mongoose");
+mongoose.set("strictQuery", false); // Prepare for Mongoose 7
 
 const mongoDB = userArgs[0];
 
-main().catch(err => console.log(err));
+main().catch((err) => console.log(err));
+
 async function main() {
+  console.log("Debug: About to connect");
   await mongoose.connect(mongoDB);
+  console.log("Debug: Should be connected?");
+  await createGenres();
+  await createAuthors();
+  await createBooks();
+  await createBookInstances();
+  console.log("Debug: Closing mongoose");
+  mongoose.connection.close();
 }
 
-const authors = []
-const genres = []
-const books = []
-const bookinstances = []
-
-function authorCreate(first_name, family_name, d_birth, d_death, cb) {
-  authordetail = {first_name:first_name , family_name: family_name }
-  if (d_birth != false) authordetail.date_of_birth = d_birth
-  if (d_death != false) authordetail.date_of_death = d_death
-  
-  const author = new Author(authordetail);
-       
-  author.save(function (err) {
-    if (err) {
-      cb(err, null)
-      return
-    }
-    console.log('New Author: ' + author);
-    authors.push(author)
-    cb(null, author)
-  }  );
-}
-
-function genreCreate(name, cb) {
+async function genreCreate(name) {
   const genre = new Genre({ name: name });
-       
-  genre.save(function (err) {
-    if (err) {
-      cb(err, null);
-      return;
-    }
-    console.log('New Genre: ' + genre);
-    genres.push(genre)
-    cb(null, genre);
-  }   );
+  await genre.save();
+  genres.push(genre);
+  console.log(`Added genre: ${name}`);
 }
 
-function bookCreate(title, summary, isbn, author, genre, cb) {
-  bookdetail = { 
+async function authorCreate(first_name, family_name, d_birth, d_death) {
+  authordetail = { first_name: first_name, family_name: family_name };
+  if (d_birth != false) authordetail.date_of_birth = d_birth;
+  if (d_death != false) authordetail.date_of_death = d_death;
+
+  const author = new Author(authordetail);
+
+  await author.save();
+  authors.push(author);
+  console.log(`Added author: ${first_name} ${family_name}`);
+}
+
+async function bookCreate(title, summary, isbn, author, genre) {
+  bookdetail = {
     title: title,
     summary: summary,
     author: author,
-    isbn: isbn
-  }
-  if (genre != false) bookdetail.genre = genre
-    
-  const book = new Book(bookdetail);    
-  book.save(function (err) {
-    if (err) {
-      cb(err, null)
-      return
-    }
-    console.log('New Book: ' + book);
-    books.push(book)
-    cb(null, book)
-  }  );
+    isbn: isbn,
+  };
+  if (genre != false) bookdetail.genre = genre;
+
+  const book = new Book(bookdetail);
+  await book.save();
+  books.push(book);
+  console.log(`Added book: ${title}`);
 }
 
-
-function bookInstanceCreate(book, imprint, due_back, status, cb) {
-  bookinstancedetail = { 
+async function bookInstanceCreate(book, imprint, due_back, status) {
+  bookinstancedetail = {
     book: book,
-    imprint: imprint
-  }    
-  if (due_back != false) bookinstancedetail.due_back = due_back
-  if (status != false) bookinstancedetail.status = status
-    
-  const bookinstance = new BookInstance(bookinstancedetail);    
-  bookinstance.save(function (err) {
-    if (err) {
-      console.log('ERROR CREATING BookInstance: ' + bookinstance);
-      cb(err, null)
-      return
-    }
-    console.log('New BookInstance: ' + bookinstance);
-    bookinstances.push(bookinstance)
-    cb(null, book)
-  }  );
+    imprint: imprint,
+  };
+  if (due_back != false) bookinstancedetail.due_back = due_back;
+  if (status != false) bookinstancedetail.status = status;
+
+  const bookinstance = new BookInstance(bookinstancedetail);
+  await bookinstance.save();
+  bookinstances.push(bookinstance);
+  console.log(`Added bookinstance: ${imprint}`);
 }
 
-
-function createGenreAuthors(cb) {
-    async.series([
-        function(callback) {
-          authorCreate('Patrick', 'Rothfuss', '1973-06-06', false, callback);
-        },
-        function(callback) {
-          authorCreate('Ben', 'Bova', '1932-11-8', false, callback);
-        },
-        function(callback) {
-          authorCreate('Isaac', 'Asimov', '1920-01-02', '1992-04-06', callback);
-        },
-        function(callback) {
-          authorCreate('Bob', 'Billings', false, false, callback);
-        },
-        function(callback) {
-          authorCreate('Jim', 'Jones', '1971-12-16', false, callback);
-        },
-        function(callback) {
-          genreCreate("Fantasy", callback);
-        },
-        function(callback) {
-          genreCreate("Science Fiction", callback);
-        },
-        function(callback) {
-          genreCreate("French Poetry", callback);
-        },
-        ],
-        // optional callback
-        cb);
+async function createGenres() {
+  console.log("Adding genres");
+  await Promise.all([
+    genreCreate("Fantasy"),
+    genreCreate("Science Fiction"),
+    genreCreate("French Poetry"),
+  ]);
 }
 
-
-function createBooks(cb) {
-    async.parallel([
-        function(callback) {
-          bookCreate('The Name of the Wind (The Kingkiller Chronicle, #1)', 'I have stolen princesses back from sleeping barrow kings. I burned down the town of Trebon. I have spent the night with Felurian and left with both my sanity and my life. I was expelled from the University at a younger age than most people are allowed in. I tread paths by moonlight that others fear to speak of during day. I have talked to Gods, loved women, and written songs that make the minstrels weep.', '9781473211896', authors[0], [genres[0],], callback);
-        },
-        function(callback) {
-          bookCreate("The Wise Man's Fear (The Kingkiller Chronicle, #2)", 'Picking up the tale of Kvothe Kingkiller once again, we follow him into exile, into political intrigue, courtship, adventure, love and magic... and further along the path that has turned Kvothe, the mightiest magician of his age, a legend in his own time, into Kote, the unassuming pub landlord.', '9788401352836', authors[0], [genres[0],], callback);
-        },
-        function(callback) {
-          bookCreate("The Slow Regard of Silent Things (Kingkiller Chronicle)", 'Deep below the University, there is a dark place. Few people know of it: a broken web of ancient passageways and abandoned rooms. A young woman lives there, tucked among the sprawling tunnels of the Underthing, snug in the heart of this forgotten place.', '9780756411336', authors[0], [genres[0],], callback);
-        },
-        function(callback) {
-          bookCreate("Apes and Angels", "Humankind headed out to the stars not for conquest, nor exploration, nor even for curiosity. Humans went to the stars in a desperate crusade to save intelligent life wherever they found it. A wave of death is spreading through the Milky Way galaxy, an expanding sphere of lethal gamma ...", '9780765379528', authors[1], [genres[1],], callback);
-        },
-        function(callback) {
-          bookCreate("Death Wave","In Ben Bova's previous novel New Earth, Jordan Kell led the first human mission beyond the solar system. They discovered the ruins of an ancient alien civilization. But one alien AI survived, and it revealed to Jordan Kell that an explosion in the black hole at the heart of the Milky Way galaxy has created a wave of deadly radiation, expanding out from the core toward Earth. Unless the human race acts to save itself, all life on Earth will be wiped out...", '9780765379504', authors[1], [genres[1],], callback);
-        },
-        function(callback) {
-          bookCreate('Test Book 1', 'Summary of test book 1', 'ISBN111111', authors[4], [genres[0],genres[1]], callback);
-        },
-        function(callback) {
-          bookCreate('Test Book 2', 'Summary of test book 2', 'ISBN222222', authors[4], false, callback)
-        }
-        ],
-        // optional callback
-        cb);
+async function createAuthors() {
+  console.log("Adding authors");
+  await Promise.all([
+    authorCreate("Patrick", "Rothfuss", "1973-06-06", false),
+    authorCreate("Ben", "Bova", "1932-11-8", false),
+    authorCreate("Isaac", "Asimov", "1920-01-02", "1992-04-06"),
+    authorCreate("Bob", "Billings", false, false),
+    authorCreate("Jim", "Jones", "1971-12-16", false),
+  ]);
 }
 
-
-function createBookInstances(cb) {
-    async.parallel([
-        function(callback) {
-          bookInstanceCreate(books[0], 'London Gollancz, 2014.', false, 'Available', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[1], ' Gollancz, 2011.', false, 'Loaned', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[2], ' Gollancz, 2015.', false, false, callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[3], 'New York Tom Doherty Associates, 2016.', false, 'Available', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[3], 'New York Tom Doherty Associates, 2016.', false, 'Available', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[3], 'New York Tom Doherty Associates, 2016.', false, 'Available', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[4], 'New York, NY Tom Doherty Associates, LLC, 2015.', false, 'Available', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[4], 'New York, NY Tom Doherty Associates, LLC, 2015.', false, 'Maintenance', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[4], 'New York, NY Tom Doherty Associates, LLC, 2015.', false, 'Loaned', callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[0], 'Imprint XXX2', false, false, callback)
-        },
-        function(callback) {
-          bookInstanceCreate(books[1], 'Imprint XXX3', false, false, callback)
-        }
-        ],
-        // Optional callback
-        cb);
+async function createBooks() {
+  console.log("Adding Books");
+  await Promise.all([
+    bookCreate(
+      "The Name of the Wind (The Kingkiller Chronicle, #1)",
+      "I have stolen princesses back from sleeping barrow kings. I burned down the town of Trebon. I have spent the night with Felurian and left with both my sanity and my life. I was expelled from the University at a younger age than most people are allowed in. I tread paths by moonlight that others fear to speak of during day. I have talked to Gods, loved women, and written songs that make the minstrels weep.",
+      "9781473211896",
+      authors[0],
+      [genres[0]]
+    ),
+    bookCreate(
+      "The Wise Man's Fear (The Kingkiller Chronicle, #2)",
+      "Picking up the tale of Kvothe Kingkiller once again, we follow him into exile, into political intrigue, courtship, adventure, love and magic... and further along the path that has turned Kvothe, the mightiest magician of his age, a legend in his own time, into Kote, the unassuming pub landlord.",
+      "9788401352836",
+      authors[0],
+      [genres[0]]
+    ),
+    bookCreate(
+      "The Slow Regard of Silent Things (Kingkiller Chronicle)",
+      "Deep below the University, there is a dark place. Few people know of it: a broken web of ancient passageways and abandoned rooms. A young woman lives there, tucked among the sprawling tunnels of the Underthing, snug in the heart of this forgotten place.",
+      "9780756411336",
+      authors[0],
+      [genres[0]]
+    ),
+    bookCreate(
+      "Apes and Angels",
+      "Humankind headed out to the stars not for conquest, nor exploration, nor even for curiosity. Humans went to the stars in a desperate crusade to save intelligent life wherever they found it. A wave of death is spreading through the Milky Way galaxy, an expanding sphere of lethal gamma ...",
+      "9780765379528",
+      authors[1],
+      [genres[1]]
+    ),
+    bookCreate(
+      "Death Wave",
+      "In Ben Bova's previous novel New Earth, Jordan Kell led the first human mission beyond the solar system. They discovered the ruins of an ancient alien civilization. But one alien AI survived, and it revealed to Jordan Kell that an explosion in the black hole at the heart of the Milky Way galaxy has created a wave of deadly radiation, expanding out from the core toward Earth. Unless the human race acts to save itself, all life on Earth will be wiped out...",
+      "9780765379504",
+      authors[1],
+      [genres[1]]
+    ),
+    bookCreate(
+      "Test Book 1",
+      "Summary of test book 1",
+      "ISBN111111",
+      authors[4],
+      [genres[0], genres[1]]
+    ),
+    bookCreate(
+      "Test Book 2",
+      "Summary of test book 2",
+      "ISBN222222",
+      authors[4],
+      false
+    ),
+  ]);
 }
 
-
-
-async.series([
-    createGenreAuthors,
-    createBooks,
-    createBookInstances
-],
-// Optional callback
-function(err, results) {
-    if (err) {
-        console.log('FINAL ERR: '+err);
-    }
-    else {
-        console.log('BOOKInstances: '+bookinstances);
-        
-    }
-    // All done, disconnect from database
-    mongoose.connection.close();
-});
-
-
-
-
+async function createBookInstances() {
+  console.log("Adding authors");
+  await Promise.all([
+    bookInstanceCreate(books[0], "London Gollancz, 2014.", false, "Available"),
+    bookInstanceCreate(books[1], " Gollancz, 2011.", false, "Loaned"),
+    bookInstanceCreate(books[2], " Gollancz, 2015.", false, false),
+    bookInstanceCreate(
+      books[3],
+      "New York Tom Doherty Associates, 2016.",
+      false,
+      "Available"
+    ),
+    bookInstanceCreate(
+      books[3],
+      "New York Tom Doherty Associates, 2016.",
+      false,
+      "Available"
+    ),
+    bookInstanceCreate(
+      books[3],
+      "New York Tom Doherty Associates, 2016.",
+      false,
+      "Available"
+    ),
+    bookInstanceCreate(
+      books[4],
+      "New York, NY Tom Doherty Associates, LLC, 2015.",
+      false,
+      "Available"
+    ),
+    bookInstanceCreate(
+      books[4],
+      "New York, NY Tom Doherty Associates, LLC, 2015.",
+      false,
+      "Maintenance"
+    ),
+    bookInstanceCreate(
+      books[4],
+      "New York, NY Tom Doherty Associates, LLC, 2015.",
+      false,
+      "Loaned"
+    ),
+    bookInstanceCreate(books[0], "Imprint XXX2", false, false),
+    bookInstanceCreate(books[1], "Imprint XXX3", false, false),
+  ]);
+}


### PR DESCRIPTION
This replaces async module with JavaScript async-await. It's a little more efficient because it does creation of the genres, authors etc in parallel with each other, then in series.
I also ran prettier. So pretty.

This is a very small part of addressing https://github.com/mdn/content/issues/24972

It can go in. The docs will be a little out of sync because they tell you to install async module, and this doesn't use it any more.
But you still need to for rest of tutorial, so it does no harm.