### PR TITLE
Remove spurious commas in pug bookinstance template

### DIFF
--- a/views/bookinstance_form.pug
+++ b/views/bookinstance_form.pug
@@ -6,21 +6,21 @@ block content
   form(method='POST' action='')
     div.form-group
       label(for='book') Book:
-      select#book.form-control(type='select', placeholder='Select book' name='book' required='true' )
+      select#book.form-control(type='select' placeholder='Select book' name='book' required='true' )
         - book_list.sort(function(a, b) {let textA = a.title.toUpperCase(); let textB = b.title.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
         for book in book_list
           option(value=book._id, selected=(selected_book==book._id.toString() ? 'selected' : false) ) #{book.title}
 
     div.form-group
       label(for='imprint') Imprint:
-      input#imprint.form-control(type='text', placeholder='Publisher and date information' name='imprint' required='true' value=(undefined===bookinstance ? '' : bookinstance.imprint) )
+      input#imprint.form-control(type='text' placeholder='Publisher and date information' name='imprint' required='true' value=(undefined===bookinstance ? '' : bookinstance.imprint) )
     div.form-group
       label(for='due_back') Date when book available:
-      input#due_back.form-control(type='date', name='due_back' value=(undefined===bookinstance ? '' : bookinstance.due_back_yyyy_mm_dd))
+      input#due_back.form-control(type='date' name='due_back' value=(undefined===bookinstance ? '' : bookinstance.due_back_yyyy_mm_dd))
 
     div.form-group
       label(for='status') Status:
-      select#status.form-control(type='select', placeholder='Select status' name='status' required='true' )
+      select#status.form-control(type='select' placeholder='Select status' name='status' required='true' )
         option(value='Maintenance' selected=(undefined===bookinstance || bookinstance.status!='Maintenance' ? false:'selected')) Maintenance
         option(value='Available' selected=(undefined===bookinstance || bookinstance.status!='Available' ? false:'selected')) Available
         option(value='Loaned' selected=(undefined===bookinstance || bookinstance.status!='Loaned' ? false:'selected')) Loaned


### PR DESCRIPTION
The commas shown here are not needed. They do no harm but it works without them, and I think they probably are potentially confusing for readers.