### PR TITLE
Express case sensitive

### DIFF
--- a/controllers/genreController.js
+++ b/controllers/genreController.js
@@ -65,8 +65,10 @@ exports.genre_create_post = [
       return;
     } else {
       // Data from form is valid.
-      // Check if Genre with same name already exists.
-      const genreExists = await Genre.findOne({ name: req.body.name }).exec();
+      // Check if Genre with same name (case insensitive) already exists.
+      const genreExists = await Genre.findOne({ name: req.body.name })
+        .collation({ locale: "en", strength: 2 })
+        .exec();
       if (genreExists) {
         // Genre exists, redirect to its detail page.
         res.redirect(genreExists.url);

--- a/populatedb.js
+++ b/populatedb.js
@@ -18,7 +18,7 @@ const books = [];
 const bookinstances = [];
 
 const mongoose = require("mongoose");
-mongoose.set("strictQuery", false); // Prepare for Mongoose 7
+mongoose.set("strictQuery", false);
 
 const mongoDB = userArgs[0];
 

--- a/views/author_list.pug
+++ b/views/author_list.pug
@@ -7,7 +7,7 @@ block content
   each author in author_list
     li
       a(href=author.url) #{author.name}
-      | (#{author.lifespan})
+      |  (#{author.lifespan})
 
   else
     li There are no authors.


### PR DESCRIPTION
This makes the check for whether or not to create a new genre case insensitive - without this you can create fantasy, FANTASY, FaNtAsY and so on. 

The check only applies to genre. It doesn't make sense to apply it to Author because we might have two authors with same name, ditto for books. It might apply to bookInstances I guess, but not necessary.

This comes from contributor in https://github.com/mdn/content/pull/27648