### PR TITLE
BookInstance - improve selected option code

### DIFF
--- a/views/bookinstance_form.pug
+++ b/views/bookinstance_form.pug
@@ -9,7 +9,7 @@ block content
       select#book.form-control(type='select' placeholder='Select book' name='book' required='true' )
         - book_list.sort(function(a, b) {let textA = a.title.toUpperCase(); let textB = b.title.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
         for book in book_list
-          option(value=book._id, selected=(selected_book==book._id.toString() ? 'selected' : false) ) #{book.title}
+          option(value=book._id, selected=(selected_book==book._id.toString() ? '' : false) ) #{book.title}
 
     div.form-group
       label(for='imprint') Imprint:


### PR DESCRIPTION
This improves the pug form for the BookInstance update template so that the selected book has `<option selected>` rather than `<option selected="selected">`. NOte that both are valid, and both work. It's just that the changed version is more familiar and easier to read.

note that setting the value to `false` is somewhat arbitrary - any value other than `selected` or the null string is taken as false.

This is a response to https://github.com/mdn/content/issues/29859