### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Mostly maintained by Hamish and Brian (as of Nov '23)
+* @bsmth @hamishwillee


### PR DESCRIPTION
Adding a codeowners here might help us catch some PRs that occasionally slip through the net.

Note that we can alternatively add `@mdn/core-yari-content`:

https://github.com/mdn/content/blob/main/.github/CODEOWNERS#L12C6-L12C28
