### PR TITLE
FIX:  selection for genre count on home page

### DIFF
--- a/controllers/bookController.js
+++ b/controllers/bookController.js
@@ -19,7 +19,7 @@ exports.index = asyncHandler(async (req, res, next) => {
     BookInstance.countDocuments({}).exec(),
     BookInstance.countDocuments({ status: "Available" }).exec(),
     Author.countDocuments({}).exec(),
-    Author.countDocuments({}).exec(),
+    Genre.countDocuments({}).exec(),
   ]);
 
   res.render("index", {


### PR DESCRIPTION
Home page was showing total authors count instead of genres count. 
This PR is for showing correct count of genres on home page.