### PR TITLE
chore: Disable npm depbot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Description

We are generating the project scaffolding via Express application generator: https://expressjs.com/en/starter/generator.html

See: https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website#creating_the_project

### Motivation

Bumping individual deps uses compute resources, is time-consuming, and causes the project to diverge from what's created by the generator. I think we can skip these depbot PRs unless there are security vulns, or run the generator manually if needed (for major versions, for example).

