### PR TITLE
Book detail - stop escaping already escaped title/summary

### DIFF
--- a/views/book_detail.pug
+++ b/views/book_detail.pug
@@ -1,11 +1,11 @@
 extends layout
 
 block content
-  h1 Title: #{book.title}
+  h1 Title: !{book.title}
 
   p #[strong Author: ]
     a(href=book.author.url) #{book.author.name}
-  p #[strong Summary:] #{book.summary}
+  p #[strong Summary:] !{book.summary}
   p #[strong ISBN:] #{book.isbn}
   p #[strong Genre: ]
     each val, index in book.genre


### PR DESCRIPTION
This is the demo side fix to https://github.com/mdn/content/issues/5320

I'm unescaping the displayed data, which is escaped already by the code that validates form data