### PR TITLE
build(npm): allowlist dependency install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "supertest": "^7.1.1"
   },
   "allowScripts": {
-    "fsevents": true,
+    "fsevents": false,
     "mongodb-memory-server": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
     "mongodb-memory-server": "^10.1.4",
     "nodemon": "^3.1.10",
     "supertest": "^7.1.1"
+  },
+  "allowScripts": {
+    "fsevents": true,
+    "mongodb-memory-server": true
   }
 }


### PR DESCRIPTION
### Description

Add an `allowScripts` allowlist for `mongodb-memory-server` and deny `fsevents`.

### Motivation

npm 12 no longer runs dependency `preinstall`/`install`/`postinstall` scripts unless the root `package.json` allowlists them, and `npm ci` still exits 0, so the failure only shows up later as a missing binary. Without the entry, `mongodb-memory-server` downloads `mongod` lazily during the first test run instead, which is slow and fails offline.

### Additional details

- Entries are name-only, so dependency bumps do not need re-approval commits.
- `fsevents` is denied (`false`): its tarball ships a prebuilt binary and has no `install` script, only the registry manifest lists one.
- No workflow runs `npm ci` here, so strict mode is left for learners to opt into.
- Verified: `npm ci --strict-allow-scripts` passes on npm 12.0.2 and 11.19.0; `npm approve-scripts --allow-scripts-pending` reports nothing.

### Related issues and pull requests

Part of mdn/fred#1868.
